### PR TITLE
change default sql connection, auto generate swagger xml documentation file

### DIFF
--- a/Authentication/Authentication.WebApi/Authentication.WebApi.csproj
+++ b/Authentication/Authentication.WebApi/Authentication.WebApi.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +29,5 @@
     <ProjectReference Include="..\Authentication.Domain.Repository\Authentication.Domain.Repository.csproj" />
     <ProjectReference Include="..\Authentication.Infrastructure\Authentication.Infrastructure.csproj" />
   </ItemGroup>
-
 
 </Project>

--- a/Authentication/Authentication.WebApi/Authentication.xml
+++ b/Authentication/Authentication.WebApi/Authentication.xml
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<doc>
-  <assembly>
-    <name>EdakikApi</name>
-  </assembly>
-  <members>
-  </members>
-</doc>

--- a/Authentication/Authentication.WebApi/Startup.cs
+++ b/Authentication/Authentication.WebApi/Startup.cs
@@ -16,6 +16,8 @@ using Serilog;
 using Serilog.Sinks.Elasticsearch;
 using Swashbuckle.AspNetCore.Filters;
 using System;
+using System.IO;
+using System.Reflection;
 
 namespace Authentication.WebApi
 {
@@ -100,12 +102,10 @@ namespace Authentication.WebApi
 
                 c.SwaggerDoc("v1", inf);
 
-                var xmlPath = System.AppDomain.CurrentDomain.BaseDirectory + @"Authentication.xml";
+                var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
                 c.IncludeXmlComments(xmlPath);
-
             });
-
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -123,8 +123,8 @@ namespace Authentication.WebApi
             app.UseExceptionMiddleWare();
             app.UseAuthorizationMiddleWare();
             app.UseHttpsRedirection();
-         
-          
+
+
             app.UseSwagger();
             app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Authentication Api"));
 

--- a/Authentication/Authentication.WebApi/appsettings.json
+++ b/Authentication/Authentication.WebApi/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=DESKTOP-IRQA9QE;Database=Authentication2020;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Authentication2020;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "TokenOptions": {
     "Audience": "https://localhost:44300/",
@@ -30,5 +30,3 @@
   },
   "AllowedHosts": "*"
 }
-
- 


### PR DESCRIPTION
### Change default sql connection:
I changed the default connection string in `appsettings.json` into a "general" one, so people can easily do ```update-database``` in package manager console and the db will generated as localdb.

```diff
-"DefaultConnection": "Server=DESKTOP-IRQA9QE;Database=Authentication2020;Trusted_Connection=True;MultipleActiveResultSets=true"
+"DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Authentication2020;Trusted_Connection=True;MultipleActiveResultSets=true"
```
### Swagger xml documentation file:
According to [Swagger XML Comments](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-3.1&tabs=visual-studio#xml-comments) we can enable XML comments with the following approach:
```javascript
<GenerateDocumentationFile>true</GenerateDocumentationFile>
```
and build an XML file name matching that of the web API project: 
```diff
- var xmlPath = System.AppDomain.CurrentDomain.BaseDirectory + @"Authentication.xml";
+ var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+ var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
```
However undocumented types and members are indicated by the warning message (warning code 1591):
```
warning CS1591: Missing XML comment for publicly visible type or member 'AuthenticationController.GetUsers()'
```
To suppress warning for undocumented types, we can use the ```<NoWarn>``` tag:
```javascript
<NoWarn>$(NoWarn);1591</NoWarn>
```
Or by adding ```<summary>``` to all actions 😄
```javascript
/// <summary>
/// Get all users.
/// </summary>
/// <param name="request"></param>
/// <returns>Returns requested users</returns>
[HttpPost]
[Route("/api/v1/GetUsers")]
public GetUserListResponseDTO GetUsers(GetUserRequestDTO request)
{
     return AuthenticationService.GetUsers(request);
}
```